### PR TITLE
fix(BEAC-1783): keep context-menu open on FF

### DIFF
--- a/addon/components/context-menu.js
+++ b/addon/components/context-menu.js
@@ -29,7 +29,7 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.setWormholeTarget();
-    window.addEventListener('click', this.closeOnClickOutside.bind(this));
+    window.addEventListener('mousedown', this.closeOnClickOutside.bind(this));
   },
 
   closeOnClickOutside(event) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-context-menu",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Ember addon for right-click--menu",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
On Firefox, the context menu closes imediatelly after the right-click (since another click event is sent end triggers 'closeOnClickOutside')

This fix should keep the menu opened on Firefox and allow the actions described in these bugs:
https://gliffy.atlassian.net/browse/BEAC-1783  &
https://gliffy.atlassian.net/browse/BEAC-1782